### PR TITLE
cache setting up implementation

### DIFF
--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -15,5 +15,9 @@ framework:
         #app: cache.adapter.apcu
 
         # Namespaced pools use the above "app" backend by default
-        #pools:
+        pools:
             #my.dedicated.cache: null
+            product_pool:
+                default_lifetime: 604800 # expires after one week
+            user_pool:
+                default_lifetime: 604800 # expires after one week

--- a/src/Repository/ProductRepository.php
+++ b/src/Repository/ProductRepository.php
@@ -27,7 +27,7 @@ class ProductRepository extends ServiceEntityRepository
      * @param int $page
      * @return Product[] Array of Product objects
      */
-    public function paginatedSearch(string $keyword, int $order, int $limit, int $page)
+    public function paginatedSearch(string $keyword, string $order, int $limit, int $page)
     {
         $offset = ($page - 1) * $limit;
 


### PR DESCRIPTION
Configuration of two custom pools in cache.yaml
These are product_pool and user_pool.
They're used in code by autowiring  via a CacheItemPoolInterface  and CacheInterface respectively.
CacheItemPoolInterface is used for product_pool management due to the need of a method to clear the pool, made possible by PSR-6 implementation.
In the actual asked implementation, the pool must be cleared when products are added, updated or deleted in database by Bilemo, as the current internal process of Bilemo in proposed products evolution.
In order to do this pool clearing, a confidential endpoint was added, accessible under the url path /api/products_cache_delete
CacheInterface is used for user_pool management due to the more concise way to use it.
Every endpoint using the user_pool cache delete directly every key of cache made outdated by itself.
